### PR TITLE
pass correct variable to nvim_buf_get_option

### DIFF
--- a/lua/scmindent.lua
+++ b/lua/scmindent.lua
@@ -293,7 +293,7 @@ if running_in_neovim then
   scmindent.GetScmIndent = function(lnum1)
     local lnum = lnum1 - 1 -- convert to 0-based line number
     local curr_buf = vim.api.nvim_get_current_buf()
-    local curr_filetype = vim.api.nvim_buf_get_option(buf, 'filetype')
+    local curr_filetype = vim.api.nvim_buf_get_option(curr_buf, 'filetype')
     if curr_filetype ~= prevailing_filetype then
       prevailing_filetype = curr_filetype
       slurp_in_lw(curr_buf)


### PR DESCRIPTION
Fixes #1 

Previously we were passing 'buf', which is undefined, evaluating to nil. It looks like in previous versions of neovim, this was accepted
(probably coerced to the number 0), and evaluated as the current buffer. At some point, this was changed and newer versions of neovim will throw an error because the argument is not a number.